### PR TITLE
Update pandas to 0.21.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 matplotlib==1.5.1
 nltk==3.2.1
 numpy==1.11.0
-pandas==0.18.0
+pandas==0.21.0
 pytest==2.8.1
 scipy==0.17.0
 tensorflow==0.12.0rc0


### PR DESCRIPTION
Without this, the following issue is thrown:

```
RuntimeError: module compiled against API version 0xb but this version of numpy is 0xa
Traceback (most recent call last):
  File "extracter_script.py", line 1, in <module>
    from helpers.extracter import Spider
  File "/home/eukaryote/workspace/deep-summarization/helpers/extracter.py", line 2, in <module>
    import pandas as pd
  File "/home/eukaryote/workspace/deep-summarization/local/lib/python2.7/site-packages/pandas/__init__.py", line 31, in <module>
    "extensions first.".format(module))
ImportError: C extension: umpy.core.multiarray failed to import not built. If you want to import pandas from the source directory, you may need to run 'python setup.py build_ext --inplace' to build the C extensions first.

```